### PR TITLE
Unix compliant

### DIFF
--- a/RetroView/RetroView.pro
+++ b/RetroView/RetroView.pro
@@ -46,7 +46,7 @@ include(../RetroCommon/RetroCommon.pri)
 include(../PakLib/PakLib.pri)
 include(../TXTRLoader/TXTRLoader.pri)
 
-TARGET    = RetroView
+TARGET    = retroview
 CONFIG   += console
 CONFIG   += app_bundle
 

--- a/RetroView/src/main.cpp
+++ b/RetroView/src/main.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QStandardPaths>
+#include <QSettings>
 #include <QDebug>
 
 QString getSource(QString Filename)
@@ -34,6 +35,8 @@ int main(int argc, char *argv[])
     a.setWindowIcon(QIcon(":/icons/64x64/apps/retroview.png"));
     a.setOrganizationName("MetPrimeTools");
     a.setApplicationName("RetroView");
+
+    QSettings().setValue("applicationRootPath", a.applicationDirPath());
 
     QFileInfo fi(a.applicationDirPath() + "/templates");
     if (fi.exists() && fi.isWritable())


### PR DESCRIPTION
We should be UNIX compliant, and use a lowercase executable name. No need to ruffle the feathers of hardened linux users.